### PR TITLE
Removing reference to polyfill.io

### DIFF
--- a/track.html
+++ b/track.html
@@ -2,7 +2,6 @@
 	<head>
 		<script type="text/javascript" src="https://code.jquery.com/jquery-3.6.0.js"></script>
 		<script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>	
-		<script src="https://polyfill.io/v3/polyfill.min.js?features=default"></script>  
 		<script src="//cdn.split.io/sdk/split-10.21.1.min.js"></script>
 		<title>Atwood Example App</title>
 


### PR DESCRIPTION
Tested this and I see no issue with a lack of a polyfill. 

The Plotty library is not loading due to CORS constraints but it's unrelated. 